### PR TITLE
add hyperjump cmd and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Type the letters displayed in brackets to open menus or to perform the correspon
 After navigating to another screen, type `<c-o>` to return to the main
 request/response screen.
 
+Use the command `:HyperJump` while in an http file to load the request under the cursor and open the main window.
+
 #### Body
 
 The body menu appears when a method that supports a body has been selected. The content entered must be valid JSON.

--- a/lua/hyper/http-parser.lua
+++ b/lua/hyper/http-parser.lua
@@ -8,6 +8,7 @@ local function reset_request()
     headers = {},
     body = nil,
     variables = {},
+    _end = nil,
   }
 end
 
@@ -109,6 +110,7 @@ function M.parse(file)
         if hash_comment == "###" then
           if gatheringRequest then
             gatheringRequest = false
+            req._end = i - 1
             table.insert(requests, req)
             req = reset_request()
           end
@@ -180,6 +182,7 @@ function M.parse(file)
     -- check for end of file, add current request
     if i == #file then
       if gatheringRequest then
+        req._end = i
         table.insert(requests, req)
       end
     end

--- a/lua/hyper/util.lua
+++ b/lua/hyper/util.lua
@@ -408,8 +408,6 @@ function M.select_request(state, request)
     state.set_state("query_params", request.query_params or {})
     state.set_state("headers", request.headers or {})
     state.set_state("body", request.body or {})
-
-    vim.api.nvim_input("<c-o>")
 end
 
 function M.get_status_hl(code)

--- a/lua/hyper/view/screens/collections.lua
+++ b/lua/hyper/view/screens/collections.lua
@@ -142,6 +142,7 @@ function M.new(State, View)
     local req = collections[coll_list_win.selection + 1].requests[req_list_win.selection + 1]
 
     Util.select_request(State, req)
+    vim.api.nvim_input("<c-o>")
   end})
 
   coll_list_win:add_keymap({"n", "j", function()

--- a/lua/hyper/view/screens/history.lua
+++ b/lua/hyper/view/screens/history.lua
@@ -76,6 +76,7 @@ function M.new(State)
     local request = History.requests[id]
 
     Util.select_request(State, request)
+    vim.api.nvim_input("<c-o>")
   end})
 
   return HistoryScreen

--- a/plugin/hyper.lua
+++ b/plugin/hyper.lua
@@ -4,3 +4,6 @@ vim.api.nvim_create_user_command("Hyper", function(cmd)
   View.show()
 end, {})
 
+vim.api.nvim_create_user_command("HyperJump", function(cmd)
+  View:jump()
+end, {})


### PR DESCRIPTION
users can now execute the HyperJump command while in an HTTP file, which will load the request and open Hyper to the main page (the cursor location determines the request selected)