### PR TITLE
fix function call for hyperjump

### DIFF
--- a/lua/hyper/view/init.lua
+++ b/lua/hyper/view/init.lua
@@ -66,7 +66,7 @@ function M:setup_cmds(mode)
   end
 end
 
-function M:jump()
+function M.jump()
   local path = vim.api.nvim_buf_get_name(0)
   if vim.fn.filereadable(path) == 0 or path:match('.*%.http$') == nil then
     vim.notify("HyperJump failed: must be in a valid http file", vim.log.levels.WARN)
@@ -82,7 +82,7 @@ function M:jump()
     if row <= req._end then
       Util.select_request(State, req)
       State.set_state("mode", "main")
-      self.show()
+      M.show()
       break
     end
   end

--- a/plugin/hyper.lua
+++ b/plugin/hyper.lua
@@ -5,5 +5,5 @@ vim.api.nvim_create_user_command("Hyper", function(cmd)
 end, {})
 
 vim.api.nvim_create_user_command("HyperJump", function(cmd)
-  View:jump()
+  View.jump()
 end, {})


### PR DESCRIPTION
remove implicit self parameter from the hyperjump function, allows using `require("hyper.view").jump` to setup keymaps